### PR TITLE
feat: add new option `suppressDuplicateTitles`

### DIFF
--- a/MMM-anotherNewsFeed.js
+++ b/MMM-anotherNewsFeed.js
@@ -178,7 +178,7 @@ Module.register("MMM-anotherNewsFeed", {
 					item.sourceTitle = this.titleForFeed(feed);
 					if (!(this.config.ignoreOldItems && Date.now() - new Date(item.pubdate) > this.config.ignoreOlderThan)) {
 						if (this.config.suppressDuplicateTitles) {
-							if (!duplicateTitle(newsItems, item)) {
+							if (!this.duplicateTitle(newsItems, item)) {
 								newsItems.push(item);
 							}
 						} else {


### PR DESCRIPTION
When set to true, it removes news items that have duplicate titles from the feed. This is useful when your rss feeds include duplicate news items. For example, Bloomberg has an rss feed per topic, and often articles are duplicated across topics.