### PR TITLE
Support RSS media:thumbnail images

### DIFF
--- a/newsfeedfetcher.js
+++ b/newsfeedfetcher.js
@@ -52,18 +52,36 @@ const NewsfeedFetcher = function (url, reloadInterval, encoding, logFeedWarnings
       const url = item.url || item.link || "";
 
       let images = []
+			const addImageUrls = (value, type = null) => {
+				if (!value) {
+					return;
+				}
+
+				const values = Array.isArray(value) ? value : [value];
+				for (const entry of values) {
+					if (typeof entry === "string") {
+						if (isImage(entry, type)) {
+							images.push(entry);
+						}
+						continue;
+					}
+
+					const candidateUrl = entry?.url || entry?.href;
+					const candidateType = entry?.type || type;
+					if (isImage(candidateUrl, candidateType)) {
+						images.push(candidateUrl);
+					}
+				}
+			}
 
 			if (Array.isArray(item?.link)) {
 				images = [...images, ...(item.link.filter((i) => {
-					return isImage(i?.href ?? '')
-				}).map((i) => { return i.href}))]
+					return isImage(i?.href ?? "")
+				}).map((i) => { return i.href }))]
 			}
-			if (isImage(item?.enclosure?.url, item?.enclosure?.type)) {
-				images.push(item.enclosure.url)
-			}
-			if (isImage(item?.['media:content']?.url)) {
-				images.push(item['media:content'].url)
-      }
+			addImageUrls(item?.enclosure)
+			addImageUrls(item?.["media:content"])
+			addImageUrls(item?.["media:thumbnail"], "image")
 
       // Check both description and content:encoded for img tags
 			const contentToCheck = [


### PR DESCRIPTION
## Summary
- add shared image URL extraction for existing feed image fields
- detect RSS `media:thumbnail` entries in addition to `media:content`, `enclosure`, and inline `<img>` tags
- keep the change scoped to the fetcher so existing module behavior stays intact

## Why
Some feeds such as ABC and BBC expose article images primarily through `media:thumbnail`. With `showImage: true`, headlines render but images stay empty because those tags are not currently inspected.

Closes #15.

## Validation
- `node --check newsfeedfetcher.js`
- confirmed the change is isolated to the upstream dev clone in `~/dev/MMM-anotherNewsFeed` and does not modify the live installed module
